### PR TITLE
Fixed bad iterated Gaussian fits.

### DIFF
--- a/Utils_Python/Utils_StatsAndFits.py
+++ b/Utils_Python/Utils_StatsAndFits.py
@@ -963,6 +963,17 @@ def check_fit_convergence(stat_ls, max_perc_diff=5, compare_to_last=3, alarm_lev
         if alarm in "ERROR":
             raise ValueError
 
+def get_status_redchi2_fit(red_chi2, min_rc2, max_rc2):
+    """Return True if: min_rc2 < reduced chi^2 value < max_rc2."""
+    if (red_chi2 < min_rc2):
+        print(f"Reduced chi^2 ({red_chi2}) is less than minimum allowed: {min_rc2}")
+        return False
+    elif (red_chi2 > max_rc2):
+        print(f"Reduced chi^2 ({red_chi2}) is greater than minimum allowed: {max_rc2}")
+        return False
+    else:
+        return True
+
 def get_bestfit_vals_from_statsdict(d, check_convergence=False):
     """Return the best-fit mean, mean_err, std, std_err from a dict."""
     if check_convergence:

--- a/Utils_ROOT/ROOT_Plotting.py
+++ b/Utils_ROOT/ROOT_Plotting.py
@@ -1,6 +1,40 @@
 import ROOT as r
 from Utils_Python.Plot_Styles_ROOT.tdrstyle_official import setTDRStyle, tdrGrid
 
+def make_TPave(w, h, topright_corner_pos=(0.33, 0.62)):#, when="Before"):
+    """Return a TPaveText that shows either before or after corr stats.
+    
+    NOTE: I want to move this function to ROOT_classes but the pkls are 
+    Parameters
+    ----------
+    topright_corner_pos : 2-tup
+        (x_max, y_max) coordinate of pave.
+    when : str
+        Should be either 'Before' or 'After'
+    """
+    # color = r.kBlue if when.lower() in "before" else r.kRed
+    x_right, y_top = topright_corner_pos[0], topright_corner_pos[1]
+    assert x_right >= w
+    assert y_top >= h
+    x_left = x_right - w
+    y_bot = y_top - h
+
+    pave = r.TPaveText(x_left, y_bot, x_right, y_top, "NDC")
+    # pave = r.TPaveText(0.13, text_y_min-0.11, 0.33, text_y_min, "NDC")
+    pave.SetFillColor(0)
+    pave.SetBorderSize(1) # Use 0 for no border.
+    pave.SetTextAlign(12) # 22 is centered vert and horiz.
+    pave.SetTextSize(0.016)
+    # pave.SetTextColor(1)
+    pave.SetFillStyle(1001)  # Solid fill.
+    # pave.AddText(f"Used %i Gaus fit iterations per fit" % iters)  # Accommodates LaTeX!
+    # pave.SetTextColor(color)
+    # pave.AddText(r"%s p_{T} corrections:" % when)
+    # pave.AddText(f"  #mu = {mean.getVal():.4g} #pm {mean.getError():.4g}")
+    # pave.AddText(f"  #sigma = {sigma.getVal():.4g} #pm {sigma.getError():.4g}")
+    # pave.AddText(r"  #chi^{2}/ndf = %.4g" % xframe.chiSquare())
+    return pave
+
 def make_ratio_pads():
     """Create an upper pad (for hists), and a lower pad (for a ratio plot)."""
     ptop = r.TPad("ptop", "pad main", 0.0, 0.25, 1.0, 1.0)

--- a/Utils_ROOT/ROOT_classes.py
+++ b/Utils_ROOT/ROOT_classes.py
@@ -239,39 +239,6 @@ def make_TMultiGraph_and_Legend(gr_ls=[], leg_txt_ls=[], y_min=None, y_max=None,
         mg.SetMaximum(y_max)
     return (mg, leg)
 
-def make_TPave(w, h, topright_corner_pos=(0.33, 0.62)):#, when="Before"):
-    """Return a TPaveText that shows either before or after corr stats.
-    
-    Parameters
-    ----------
-    topright_corner_pos : 2-tup
-        (x_max, y_max) coordinate of pave.
-    when : str
-        Should be either 'Before' or 'After'
-    """
-    # color = r.kBlue if when.lower() in "before" else r.kRed
-    x_right, y_top = topright_corner_pos[0], topright_corner_pos[1]
-    assert x_right >= w
-    assert y_top >= h
-    x_left = x_right - w
-    y_bot = y_top - h
-
-    pave = r.TPaveText(x_left, y_bot, x_right, y_top, "NDC")
-    # pave = r.TPaveText(0.13, text_y_min-0.11, 0.33, text_y_min, "NDC")
-    pave.SetFillColor(0)
-    pave.SetBorderSize(1) # Use 0 for no border.
-    pave.SetTextAlign(12) # 22 is centered vert and horiz.
-    pave.SetTextSize(0.016)
-    # pave.SetTextColor(1)
-    pave.SetFillStyle(1001)  # Solid fill.
-    # pave.AddText(f"Used %i Gaus fit iterations per fit" % iters)  # Accommodates LaTeX!
-    # pave.SetTextColor(color)
-    # pave.AddText(r"%s p_{T} corrections:" % when)
-    # pave.AddText(f"  #mu = {mean.getVal():.4g} #pm {mean.getError():.4g}")
-    # pave.AddText(f"  #sigma = {sigma.getVal():.4g} #pm {sigma.getError():.4g}")
-    # pave.AddText(r"  #chi^{2}/ndf = %.4g" % xframe.chiSquare())
-    return pave
-
 def add_branch_to_TTree(tree, br):
     """Add a branch (`br`) to `tree` and return the pointer to `br`.
     

--- a/d0_Studies/RochCorrAnalyzers/roch_vs_noroch_itergausfit_local.py
+++ b/d0_Studies/RochCorrAnalyzers/roch_vs_noroch_itergausfit_local.py
@@ -10,7 +10,7 @@ and so you should use the following files to control this one:
 - 
 
 Author: Jake Rosenzweig
-Updated: 2021-02-05
+Updated: 2021-02-24
 """
 from Utils_Python.Utils_Files import open_pkl, save_to_pkl
 from Utils_Python.Utils_Files import check_overwrite
@@ -23,21 +23,26 @@ import gc
 overwrite = 0
 verbose = 0
 iters = 5
+verbose = 1
 fit_whole_range_first_iter = False  # False gives much more consistent fits.
+use_data_in_xlim = True
 # eta_ls = equal_entry_bin_edges_eta_mod1_wholenum #[0.0, 0.9, 1.7, 2.4]
 # pT_ls = bin_edges_pT_sevenfifths_to1000GeV_wholenum#[5, 25, 50, 100]
 # inpath_pkl = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/pickles/MC2018ggH_KB2D_onlymuoninfo_fullstats_pTbinsroundnumbers_75then200GeV.pkl"
 inpath_pkl = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/pickles/test/fixitergaussfits_test01_3kbds.pkl"
-# Outpath info is controlled by d0_Studies/d0_Analyzers/submit_to_slurm_inbatch.py
-eta_range = REPLACE_ETA_LS
-# eta_range = [0.0, 0.2]
+#--- Output ---#
+outdir_pkl = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/pickles/test/"
+outdir_txt = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/output/test/"
+outdir_pdf = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/plots/test/"
+filename = "RC_vs_NoRC_itergaussfits_fullstats_fixitergauss_test05_definitelyunbinned"
+eta_range = [0.2, 0.4]
 
 if __name__ == "__main__":
     eta_str = f"{eta_range[0]}eta{eta_range[1]}".replace(".", "p")
-    filename = f"REPLACE_JOB_NAME_{iters}iters_{eta_str}"
-    outpath_pkl = os.path.join("REPLACE_OUTDIR_PKL", f"{filename}.pkl")
-    outpath_txt = os.path.join("REPLACE_OUTDIR_TXT", f"{filename}.txt")
-    outpath_pdf = os.path.join("REPLACE_OUTDIR_PDF", f"{filename}.pdf")
+    filename = f"{filename}_{iters}iters_{eta_str}"
+    outpath_pkl = os.path.join(outdir_pkl, f"{filename}.pkl")
+    outpath_txt = os.path.join(outdir_txt, f"{filename}.txt")
+    outpath_pdf = os.path.join(outdir_pdf, f"{filename}.pdf")
     # f"/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/output/{filename}.txt"
     check_overwrite(outpath_pkl, overwrite)
     check_overwrite(outpath_txt, overwrite)
@@ -49,51 +54,64 @@ if __name__ == "__main__":
     # org_kb2d.read_KB2D_from_pkl(inpath_pkl)
     muon_coll = open_pkl(inpath_pkl)
     new_dct = {}
-    for kb2d in muon_coll.KinBin2D_dict.values():
+    for kb2d in muon_coll.values():
         if kb2d.eta_range == eta_range:
             print(f"...Doing iter Gaus fit on: eta_range={kb2d.eta_range}, pT_range={kb2d.pT_range}")
             # RochCorr vs. reco
+            # pT_RC_arr = [mu.pT_RC for mu in kb2d.muon_ls]
+            # pT_arr = [mu.pT for mu in kb2d.muon_ls]
+            # data = [mu.pT_RC for mu in kb2d.muon_ls]
+
+            # dpT_RC_reco = (pT_RC_arr - pT_arr) * 1000.0
+            # dpT_RC_reco[(dpT_RC_reco > x_lim)]
+
             kb2d.dpT_RC_reco_fit_dct, kb2d.dpT_RC_reco_frame = RooFit_iterative_gaus_fit(
                                     data=[(mu.pT_RC - mu.pT) * 1000.0 for mu in kb2d.muon_ls], 
                                     binned_fit=False, switch_to_binned_fit=2000, iters=iters, num_sigmas=2.5,
                                     n_bins=100, x_lim=[-500,500], fit_whole_range_first_iter=fit_whole_range_first_iter,
                                     xframe=None, x_label=r"p_{T}^{RC} - p_{T}^{reco}", title="%s" % kb2d.make_latex_bin_cut_str(), 
-                                    units="MeV", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose)
+                                    units="MeV", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose,
+                                    use_data_in_xlim=use_data_in_xlim)
             # Scaled by pT.
             kb2d.dpTOverpT_RC_reco_fit_dct, kb2d.dpTOverpT_RC_reco_frame = RooFit_iterative_gaus_fit(
                                     data=[((mu.pT_RC - mu.pT)/mu.pT) * 100.0 for mu in kb2d.muon_ls], 
-                                    binned_fit=False, switch_to_binned_fit=2000, iters=iters, num_sigmas=2.5,
+                                    binned_fit=False, switch_to_binned_fit=5000, iters=iters, num_sigmas=2.5,
                                     n_bins=100, x_lim=[-2,2], fit_whole_range_first_iter=fit_whole_range_first_iter,
                                     xframe=None, x_label=r"(p_{T}^{RC} - p_{T}^{reco})/p_{T}^{reco}", title="%s" % kb2d.make_latex_bin_cut_str(), 
-                                    units="%", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose)
+                                    units="%", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose,
+                                    use_data_in_xlim=False)
             # RochCorr vs. gen
             kb2d.dpT_RC_gen_fit_dct, kb2d.dpT_RC_gen_frame = RooFit_iterative_gaus_fit(
                                     data=[(mu.pT_RC - mu.gen_pT) for mu in kb2d.muon_ls], 
                                     binned_fit=False, switch_to_binned_fit=2000, iters=iters, num_sigmas=2.5,
                                     n_bins=100, x_lim=[-20,20], fit_whole_range_first_iter=fit_whole_range_first_iter,
                                     xframe=None, x_label=r"p_{T}^{RC} - p_{T}^{gen}", title="%s" % kb2d.make_latex_bin_cut_str(), 
-                                    units="GeV", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose)
+                                    units="GeV", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose,
+                                    use_data_in_xlim=use_data_in_xlim)
             # Scaled by pT.
             kb2d.dpTOverpT_RC_gen_fit_dct, kb2d.dpTOverpT_RC_gen_frame = RooFit_iterative_gaus_fit(
                                     data=[((mu.pT_RC - mu.gen_pT)/mu.gen_pT) * 100.0 for mu in kb2d.muon_ls], 
                                     binned_fit=False, switch_to_binned_fit=2000, iters=iters, num_sigmas=2.5,
                                     n_bins=100, x_lim=[-10,10], fit_whole_range_first_iter=fit_whole_range_first_iter,
                                     xframe=None, x_label=r"(p_{T}^{RC} - p_{T}^{gen})/p_{T}^{gen}", title="%s" % kb2d.make_latex_bin_cut_str(), 
-                                    units="%", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose)
+                                    units="%", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose,
+                                    use_data_in_xlim=use_data_in_xlim)
             # reco vs. gen
             kb2d.dpT_reco_gen_fit_dct, kb2d.dpT_reco_gen_frame = RooFit_iterative_gaus_fit(
                                     data=[(mu.pT - mu.gen_pT) for mu in kb2d.muon_ls], 
                                     binned_fit=False, switch_to_binned_fit=2000, iters=iters, num_sigmas=2.5,
                                     n_bins=100, x_lim=[-20,20], fit_whole_range_first_iter=fit_whole_range_first_iter,
                                     xframe=None, x_label=r"p_{T}^{reco} - p_{T}^{gen}", title="%s" % kb2d.make_latex_bin_cut_str(), 
-                                    units="GeV", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose)
+                                    units="GeV", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose,
+                                    use_data_in_xlim=use_data_in_xlim)
             # Scaled by pT.
             kb2d.dpTOverpT_reco_gen_fit_dct, kb2d.dpTOverpT_reco_gen_frame = RooFit_iterative_gaus_fit(
                                     data=[((mu.pT - mu.gen_pT)/mu.gen_pT) * 100.0 for mu in kb2d.muon_ls], 
                                     binned_fit=False, switch_to_binned_fit=2000, iters=iters, num_sigmas=2.5,
-                                    n_bins=100, x_lim=[-10,10], fit_whole_range_first_iter=fit_whole_range_first_iter,
+                                    n_bins=100, x_lim=[-10,10], fit_whole_range_first_iter=True,
                                     xframe=None, x_label=r"(p_{T}^{reco} - p_{T}^{gen})/p_{T}^{gen}", title="%s" % kb2d.make_latex_bin_cut_str(), 
-                                    units="%", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose)
+                                    units="%", marker_color=1, force_last_line_color=None, only_draw_last=False, verbose=verbose,
+                                    use_data_in_xlim=use_data_in_xlim)
             key = kb2d.get_bin_key()
             new_dct[key] = kb2d
             gc.collect()

--- a/d0_Studies/d0_Analyzers/submit_to_slurm_inbatch.py
+++ b/d0_Studies/d0_Analyzers/submit_to_slurm_inbatch.py
@@ -22,7 +22,7 @@ NOTE:
     - `REPLACE_NEW_FILE` : file path to main template script
 
 Author: Jake Rosenzweig
-Updated: 2021-02-05
+Updated: 2021-02-22
 """
 from Utils_Python.Utils_Files import replace_value, make_dirs
 from d0_Studies.kinematic_bins import equal_entry_bin_edges_eta_mod1_wholenum, bin_edges_pT_sevenfifths_to1000GeV_wholenum
@@ -33,8 +33,9 @@ import os
 import sys
 
 class SlurmManager:
-    """A class to handle the details of working with SLURM."""
-
+    """A class to handle the details of working with SLURM.
+    FIXME: Not implemented yet.
+    """
     def __init__(self): #, path_main, path_sbatch):
         self.file_copies_ls = []
         pass
@@ -57,18 +58,18 @@ class SlurmManager:
 #--- User Parameters ---#
 #-----------------------#
 # job_name = "RC_vs_NoRC_itergaussfits_fullstats_pT75then200GeV_extendedxaxis"
-job_name = "RC_vs_NoRC_itergaussfits_fullstats_pT75then200GeV_extendedxaxis"
+job_name = "RC_vs_NoRC_itergaussfits_fullstats_fixitergauss_test01"
 
 template_script_main = "/blue/avery/rosedj1/HiggsMassMeasurement/d0_Studies/RochCorrAnalyzers/roch_vs_noroch_itergausfit_template.py"
 # template_script_main = "/blue/avery/rosedj1/HiggsMassMeasurement/d0_Studies/d0_Analyzers/derive_pTcorrfactors_from_ggH_sample_template.py"
 template_script_slurm = "/blue/avery/rosedj1/HiggsMassMeasurement/d0_Studies/RochCorrAnalyzers/roch_vs_noroch_slurm.sbatch"
 
-outdir_copies = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/output/copies/"
-outdir_pkl    = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/pickles/"
-outdir_txt    = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/output/"
-outdir_pdf    = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/plots/"
+outdir_copies = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/output/copies/test/"
+outdir_pkl    = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/pickles/test/"
+outdir_txt    = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/output/test/"
+outdir_pdf    = "/cmsuf/data/store/user/t2/users/rosedj1/HiggsMassMeasurement/d0_studies/RochCorr/plots/test/"
 
-full_eta_ls = equal_entry_bin_edges_eta_mod1_wholenum
+full_eta_ls = [2.0, 2.1]# equal_entry_bin_edges_eta_mod1_wholenum
 
 delete_copies = False
 #------------------------#


### PR DESCRIPTION
# Problems encountered in Iterated Gaussian Fits

- The fits seemed to be stable, when all of a sudden, fit 4 or 5 would jump out of the core and give terrible fits.
   - Even though I was requesting unbinned fits, the fit would switch to a **binned** fit after say 3K events in a dist.
   - The fit range would extend from the min(data) to the max(data) which would sometimes be in under/overflow bins.
   - Therefore the core of the dist would only be contained within ~5 bins.
   - This made the fit parameters _very_ sensitive to the slightly-varying fit range. Hence, the suddenly poor fits.
- asdf

## Possible other ways to check for good fits

- Check error on sigma, relative to previous sigma errors.
- Check the relative difference between the distribution stdev and the fit sigma.
- Check if ANY fit param changes drastically (>10%?), relative to the other fit vals.
   - Make a Gauss dist of the fit params and look at the standard error of the mean.

## How to improve fits

- Ensure that the core of the dist has ~100 bins.
- Exclude under/overflow entries in fit, i.e. only fit over data in x-window.